### PR TITLE
Refactor to remove XMLUtils.getDocumentBuilder

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,14 +4,14 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'gradle'
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
-name: Test
+name: Release
 
-on: [push]
-
+on:
+  push:
+    tags:
+      - "*"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,4 +16,9 @@ jobs:
         java-version: '17'
         cache: 'gradle'
     - name: Build with Gradle
-      run: ./gradlew build --no-daemon
+      run: ./gradlew dist --no-daemon
+    - name: Deploy distribution package to releases
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          build/distributions/*.zip  

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# DITA-OT Index plug-in [![badge]](https://github.com/dita-ot/org.dita.index/actions?workflow=Java+CI)
+# DITA-OT Index plug-in [![badge]](https://github.com/dita-ot/org.dita.index/actions?workflow=Test)
 
 ## Installation
 
 Run the plug-in installation command:
 
 ```shell
-dita --install org.dita.index
+dita install org.dita.index
 ```
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -10,24 +10,35 @@ plugins {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group = 'org.dita-ot'
-version = '1.0.0'
+version = '2.0.0'
 description = """DITA Open Toolkit indexing plug-in."""
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 17
+targetCompatibility = 17
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 dependencies {
-    compile group: 'org.dita-ot', name: 'dost', version: '[2.1,)'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.xmlunit', name: 'xmlunit-core', version: '2.6.3'
-    testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version: '2.6.3'
+    implementation group: 'org.apache.ant', name: 'ant', version: '1.10.14'
+    implementation(group: 'com.google.guava', name: 'guava', version: '32.1.1-jre') {
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        exclude group: 'com.google.guava', module: 'failureaccess'
+        exclude group: 'com.google.guava', module: 'listenablefuture'
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
+    }
+    implementation group: 'net.sf.saxon', name: 'Saxon-HE', version: '12.4'
+    implementation group: 'com.ibm.icu', name: 'icu4j', version: '74.2'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.12'
+    implementation group: 'org.dita-ot', name: 'dost', version: '4.0.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.6.3'
+    testImplementation group: 'org.xmlunit', name: 'xmlunit-matchers', version: '2.6.3'
 }
 
 sourceSets {
@@ -46,12 +57,12 @@ compileTestJava.options.encoding = "UTF-8"
 jar.setArchiveFileName "${project.name}.jar"
 
 task copyInstall(type: Copy) {
-    from(configurations.runtime.allArtifacts.files)
+    from(tasks.jar.outputs.files)
     destinationDir = file("lib")
 }
 
 task dist(type: Zip) {
-    from(configurations.runtime.allArtifacts.files) {
+    from(tasks.jar.outputs.files) {
         into "lib"
     }
     from("src/main/resources") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Oct 10 19:53:32 EEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/org/dita/index/IndexPreprocessor.java
+++ b/src/main/java/org/dita/index/IndexPreprocessor.java
@@ -35,7 +35,6 @@ import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 import static org.dita.dost.util.Constants.*;
 
 import java.util.*;
-import javax.xml.parsers.DocumentBuilder;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.XMLUtils;
 import org.dita.index.configuration.IndexConfiguration;
@@ -101,8 +100,7 @@ public final class IndexPreprocessor {
    * @return read index terms
    */
   IndexPreprocessResult process(final Document input) {
-    final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
-    final Document doc = documentBuilder.newDocument();
+    final Document doc = input.getImplementation().createDocument(null, null, null);
     final Node rootElement = input.getDocumentElement();
     final List<IndexEntry> indexes = new ArrayList<>();
     final Node node = processCurrNode(rootElement, doc, indexes::add).get(0);

--- a/src/main/java/org/dita/index/IndexPreprocessorTask.java
+++ b/src/main/java/org/dita/index/IndexPreprocessorTask.java
@@ -38,6 +38,8 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Locale;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -47,7 +49,6 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.dita.dost.log.DITAOTAntLogger;
-import org.dita.dost.util.XMLUtils;
 import org.dita.index.configuration.IndexConfiguration;
 import org.dita.index.configuration.ParseException;
 import org.w3c.dom.Document;
@@ -71,7 +72,14 @@ public class IndexPreprocessorTask extends Task {
   public void execute() throws BuildException {
     checkParameters();
 
-    final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
+    final DocumentBuilder documentBuilder;
+    try {
+      final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      documentBuilder = factory.newDocumentBuilder();
+    } catch (ParserConfigurationException e) {
+      throw new BuildException(e);
+    }
 
     final Document doc;
     try {


### PR DESCRIPTION
## Description
Refactor to remove use of static `XMLUtils.getDocumentBuilder()`.

## Motivation and Context
Static `XMLUtils.getDocumentBuilder()` has been changed to an instance method is newer DITA-OT versions. To help with backwards and forwards compatibility, create new `DocumentBuilder` without the utility method.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, add a link to the issue number: Fixes #1234. -->

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Refactoring


